### PR TITLE
Add missing module

### DIFF
--- a/datos_univariados_2/requirements.txt
+++ b/datos_univariados_2/requirements.txt
@@ -2,3 +2,4 @@ jupyter
 numpy
 matplotlib
 pandas
+scipy


### PR DESCRIPTION
In the [Métodos de Monte Carlo intro](https://github.com/miguelsimon/ejercicios/blob/master/datos_univariados_2/intro.ipynb) of the exercise [datos_univariados_2](https://github.com/miguelsimon/ejercicios/tree/master/datos_univariados_2), once I ran the notebook through `make run_notebook` I got the following error when running the first cell:

![intro - Jupyter Notebook 10-15-2020 5-33-49 PM](https://user-images.githubusercontent.com/2522812/96160424-3bafb480-0f16-11eb-8ee5-c801c6efe8d3.png)

The problem is solved by adding to the requirements the missing module `scipy`.