### PR TITLE
add docker instructions

### DIFF
--- a/supervised_learning/README.md
+++ b/supervised_learning/README.md
@@ -7,8 +7,11 @@ El problema es extremadamente sencillo, pero las técnicas y herramientas introd
 - [usage](#usage)
 	- [install](#install)
 	- [run notebook](#run-notebook)
+	- [using docker](#using-docker)
 
 ## usage
+
+JAX seems to work on linux and OS X but is tricky on windows, if you run into install problems you might want to run this inside docker as described below.
 
 ### install
 
@@ -21,4 +24,24 @@ env/bin/pip install -r requirements.txt
 
 ```bash
 env/bin/jupyter notebook
+```
+
+### using docker
+
+You can run this using the standard python docker image: this command will launch an interactive docker container, mount the current directory under /supervised_learning, and map port 8888 to your host:
+
+```bash
+docker run -it --rm \
+  -v $(pwd):/supervised_learning \
+	-p 8888:8888 \
+	--workdir /supervised_learning \
+  python:3.10 /bin/bash
+```
+
+You can execute the install in the docker container, run jupyter in the container and point your browser to the appropriate url (read the output of the `jupyter notebook` command):
+
+```bash
+python3 -m venv env
+env/bin/pip install -r requirements.txt
+env/bin/jupyter notebook --no-browser --allow-root --ip=0.0.0.0 --port=8888
 ```

--- a/supervised_learning/README.md
+++ b/supervised_learning/README.md
@@ -13,6 +13,8 @@ El problema es extremadamente sencillo, pero las técnicas y herramientas introd
 
 JAX seems to work on linux and OS X but is tricky on windows, if you run into install problems you might want to run this inside docker as described below.
 
+Jax pip install [doesn't run on arm linuxes at the moment](https://github.com/google/jax/issues/13608) so if you need to run on this you might try [miniconda](https://conda.io/projects/conda/en/stable/index.html).
+
 ### install
 
 ```bash

--- a/supervised_learning/README.md
+++ b/supervised_learning/README.md
@@ -32,10 +32,10 @@ You can run this using the standard python docker image: this command will launc
 
 ```bash
 docker run -it --rm \
-  -v $(pwd):/supervised_learning \
+	-v $(pwd):/supervised_learning \
 	-p 8888:8888 \
 	--workdir /supervised_learning \
-  python:3.10 /bin/bash
+	python:3.10 /bin/bash
 ```
 
 You can execute the install in the docker container, run jupyter in the container and point your browser to the appropriate url (read the output of the `jupyter notebook` command):


### PR DESCRIPTION
Several people have reported issues with dependencies in different execution contexts eg. M1 macs, windows.

This adds instructions for running in a Dockerized context on the standard `python:3.10` docker image.

Related to #29 