### PR TITLE
fix sql string quotes

### DIFF
--- a/normalizacion_sql/README.md
+++ b/normalizacion_sql/README.md
@@ -26,15 +26,15 @@ create table people (
 
 insert into
   people(dni, firstname, lastname, address_1, pet_names)
-  values("93434423F", "isaac", "newton", "lauria 27, valencia", "paul,polly,peter");
+  values('93434423F', 'isaac', 'newton', 'lauria 27, valencia', 'paul,polly,peter');
 
 insert into
   people(dni, firstname, lastname, address_1)
-  values("73434423F", "e.t.", "jaynes", "lauria 28, valencia");
+  values('73434423F', 'e.t.', 'jaynes', 'lauria 28, valencia');
 
 insert into
   people(dni, firstname, lastname, address_1, address_2, pet_names)
-  values("53434423F", "george", "polya", "colon 01, valencia",  "tapineria 33, betera", "pepe");
+  values('53434423F', 'george', 'polya', 'colon 01, valencia',  'tapineria 33, betera', 'pepe');
 ```
 
 Pero ahora se encuentra con un problema; E.T. Jaynes le ha traído a Madonna como clienta, que presenta varias dificultades, entre ellas que tiene 3 residencias distintas; ha apuntado los datos en una servilleta provisionalmente mientras espera a que cambies el diseño de la base de datos para acomodarla:

--- a/queries_sql/README.md
+++ b/queries_sql/README.md
@@ -55,31 +55,31 @@ create table sueldos (
   euros_hour float not null
 );
 
-insert into empleados_macastre(id, name) values (0, "juana juanez");
-insert into empleados_macastre(id, name) values (1, "pepe pepez");
+insert into empleados_macastre(id, name) values (0, 'juana juanez');
+insert into empleados_macastre(id, name) values (1, 'pepe pepez');
 
-insert into sueldos (employee_name, euros_hour) values ("juana juanez", 0.6);
-insert into sueldos (employee_name, euros_hour) values ("pepe pepez", 0.75);
-insert into sueldos (employee_name, euros_hour) values ("martin martinez", 0.70);
-insert into sueldos (employee_name, euros_hour) values ("dr. maria lopez", 1.05);
+insert into sueldos (employee_name, euros_hour) values ('juana juanez', 0.6);
+insert into sueldos (employee_name, euros_hour) values ('pepe pepez', 0.75);
+insert into sueldos (employee_name, euros_hour) values ('martin martinez', 0.70);
+insert into sueldos (employee_name, euros_hour) values ('dr. maria lopez', 1.05);
 
-insert into proyectos(id, name, description) values(1, "ultrayogur", "");
+insert into proyectos(id, name, description) values(1, 'ultrayogur', '');
 insert into horas_macastre (employee_id, project_id, hours) values (0, 1, 10);
 insert into horas_macastre (employee_id, project_id, hours) values (0, 1, 22);
 insert into horas_macastre (employee_id, project_id, hours) values (1, 1, 5);
-insert into horas_valencia (employee_name, project_name, hours) values ("martin martinez", "ultrayogur", 18);
-insert into acelerador_particulas(project_name, euros) values ("ultrayogur", 2);
+insert into horas_valencia (employee_name, project_name, hours) values ('martin martinez', 'ultrayogur', 18);
+insert into acelerador_particulas(project_name, euros) values ('ultrayogur', 2);
 
-insert into proyectos(id, name, description) values(2, "megayogur", "");
+insert into proyectos(id, name, description) values(2, 'megayogur', '');
 insert into horas_macastre (employee_id, project_id, hours) values (1, 2, 10);
-insert into horas_valencia (employee_name, project_name, hours) values ("martin martinez", "megayogur", 6);
-insert into horas_valencia (employee_name, project_name, hours) values ("dr. maria lopez", "megayogur", 8);
-insert into horas_valencia (employee_name, project_name, hours) values ("dr. maria lopez", "megayogur", 23);
-insert into acelerador_particulas(project_name, euros) values ("megayogur", 1);
-insert into acelerador_particulas(project_name, euros) values ("megayogur", 2);
-insert into acelerador_particulas(project_name, euros) values ("megayogur", 8);
+insert into horas_valencia (employee_name, project_name, hours) values ('martin martinez', 'megayogur', 6);
+insert into horas_valencia (employee_name, project_name, hours) values ('dr. maria lopez', 'megayogur', 8);
+insert into horas_valencia (employee_name, project_name, hours) values ('dr. maria lopez', 'megayogur', 23);
+insert into acelerador_particulas(project_name, euros) values ('megayogur', 1);
+insert into acelerador_particulas(project_name, euros) values ('megayogur', 2);
+insert into acelerador_particulas(project_name, euros) values ('megayogur', 8);
 
-insert into proyectos(id, name, description) values(3, "jahgur", "");
+insert into proyectos(id, name, description) values(3, 'jahgur', '');
 insert into horas_macastre (employee_id, project_id, hours) values (0, 3, 12);
 insert into horas_macastre (employee_id, project_id, hours) values (0, 3, 10);
 insert into horas_macastre (employee_id, project_id, hours) values (1, 3, 3);


### PR DESCRIPTION
I was using double quotes for strings in our sqlite exercises; this seems to work on many OS X and linux systems which is why it's never been a problem until now, but is nonstandard as quoting strings in sql should be done with single quotes.

It seems sqlite on windows *doesn't* allow the nonstandard double-quote and a user ran into this.

This PR updates our sql to the standard syntax which should work everywhere.